### PR TITLE
create makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,24 @@
+.PHONY: all build unit-test clean
+
+all: build unit-test clean
+
+build: bin/wasmcc bin/wasm-pusher
+
+clean:
+	rm -rf bin/
+
+unit-test: sample-wasm-chaincode/chaincode_example02/rust/app_main.zip
+	cd wasmcc && go test -v 
+
+.PHONY: bin/wasmcc bin/wasm-pusher
+bin/wasmcc:
+	mkdir -p bin/
+	cd wasmcc/ && go build -o ../bin/wasmcc
+	rm bin/wasmcc # check that it builds, chaincode not meant to be used directly
+
+bin/wasm-pusher:
+	mkdir -p bin/
+	cd tools/wasm-pusher && go build -o ../../bin/wasm-pusher
+
+sample-wasm-chaincode/chaincode_example02/rust/app_main.zip: sample-wasm-chaincode/chaincode_example02/rust/app_main.wasm
+	zip sample-wasm-chaincode/chaincode_example02/rust/app_main.zip sample-wasm-chaincode/chaincode_example02/rust/app_main.wasm


### PR DESCRIPTION
development lifecycle
 - build
 - test
 - clean

zipfile required for tests to pass is not committed, and is ignored,
so attempt to create it on demand.

Signed-off-by: Morgan Bauer <mbauer@us.ibm.com>

Does part of #4 

example build available for view in:
https://github.com/MHBauer/fabric-chaincode-wasm/pull/1
https://travis-ci.com/MHBauer/fabric-chaincode-wasm/builds/129333930
https://travis-ci.com/MHBauer/fabric-chaincode-wasm/builds/129333942

@kleash purely as an example above. you can decide on any CI server you want. github actions, travis, azure pipelines, etc. 