### PR TITLE
rename invoke fn of wasmcc to execute

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,13 +74,13 @@ Every WebAssembly chaincode should implement `init` function.
 ### WASMCC functions available to initiate transactions
 
 
-WASMCC have three functions available to initiate transaction from clients, namely, `create`, `invoke` and `installedChaincodes` functions for a transaction
+WASMCC have three functions available to initiate transaction from clients, namely, `create`, `execute` and `installedChaincodes` functions for a transaction
 - `create` accepts wasm chaincode name, wasm chaincode in form of wasm binary or zip or hex value and the function parameters for init function of wasm chaincode
     - `create` invokes init function of wasm chaincode
     - `create` stores the chaincode in state on successful init invocation
-- `invoke` accepts wasm chaincode name, function to invoke and parameters(to be passed to wasm)
-    - `invoke` retrieves the wasm chaincode bytes from state and execute it in wasm vm
-    - `invoke` dynamically invokes the function from wasm chaincode whose name it accepted as a parameter initially. Also it will send number of transaction parameters available to wasm function
+- `execute` accepts wasm chaincode name, function to invoke and parameters(to be passed to wasm)
+    - `execute` retrieves the wasm chaincode bytes from state and execute it in wasm vm
+    - `execute` dynamically invokes the function from wasm chaincode whose name it accepted as a parameter initially. Also it will send number of transaction parameters available to wasm function
     - wasm chaincode can retrieves the parameter using exported `getParameters` function
     - wasm chaincode can returns the result and the result using `__return_result` function and. For success it should return 0 and for error it should return -1
 - `installedChaincodes` give back all installed wasm chaincodes
@@ -165,11 +165,11 @@ Transaction Structure:
  - 4th argument is account name
 
 ```
-peer chaincode query -C mychannel -n wasmcc -c '{"Args":["query","balancewasm","query","account1"]}'
+peer chaincode query -C mychannel -n wasmcc -c '{"Args":["execute","balancewasm","query","account1"]}'
 ```
 Returns response as 100
 
-**5. Invoke wasm chaincode:**
+**5. Execute wasm chaincode:**
 
 To do a state change transaction for our WebAssembly chaincode. This will transfer 10 units from account1 to account2
 
@@ -180,7 +180,7 @@ Transaction Structure:
 
 
 ```
-peer chaincode invoke -o orderer.example.com:7050 --tls true --cafile /opt/gopath/src/github.com/hyperledger/fabric/peer/crypto/ordererOrganizations/example.com/orderers/orderer.example.com/msp/tlscacerts/tlsca.example.com-cert.pem -C mychannel -n wasmcc --peerAddresses peer0.org1.example.com:7051 --tlsRootCertFiles /opt/gopath/src/github.com/hyperledger/fabric/peer/crypto/peerOrganizations/org1.example.com/peers/peer0.org1.example.com/tls/ca.crt --peerAddresses peer0.org2.example.com:9051 --tlsRootCertFiles /opt/gopath/src/github.com/hyperledger/fabric/peer/crypto/peerOrganizations/org2.example.com/peers/peer0.org2.example.com/tls/ca.crt -c '{"Args":["invoke","balancewasm","invoke","account2","account1","10"]}'
+peer chaincode invoke -o orderer.example.com:7050 --tls true --cafile /opt/gopath/src/github.com/hyperledger/fabric/peer/crypto/ordererOrganizations/example.com/orderers/orderer.example.com/msp/tlscacerts/tlsca.example.com-cert.pem -C mychannel -n wasmcc --peerAddresses peer0.org1.example.com:7051 --tlsRootCertFiles /opt/gopath/src/github.com/hyperledger/fabric/peer/crypto/peerOrganizations/org1.example.com/peers/peer0.org1.example.com/tls/ca.crt --peerAddresses peer0.org2.example.com:9051 --tlsRootCertFiles /opt/gopath/src/github.com/hyperledger/fabric/peer/crypto/peerOrganizations/org2.example.com/peers/peer0.org2.example.com/tls/ca.crt -c '{"Args":["execute","balancewasm","invoke","account2","account1","10"]}'
 ```
 
 If successful, do a query again and balance of account1 should be 110 now.

--- a/wasmcc/wasmcc.go
+++ b/wasmcc/wasmcc.go
@@ -212,15 +212,15 @@ func (t *WASMChaincode) Invoke(stub shim.ChaincodeStubInterface) pb.Response {
 	if function == "create" {
 		// Create a new wasm chaincode
 		return t.create(stub, args)
-	} else if function == "invoke" {
-		// invoke a new wasm chaincode
-		return t.invoke(stub, args)
+	} else if function == "execute" {
+		// execute wasm chaincode
+		return t.execute(stub, args)
 	} else if function == "installedChaincodes" {
 		// invoke a new wasm chaincode
 		return t.installedChaincodes(stub, args)
 	}
 
-	return shim.Error("Invalid invoke function name. Expecting \"invoke\" \"create\" \"query\"")
+	return shim.Error("Invalid invoke function name. Expecting \"execute\" \"create\" \"query\"")
 }
 
 func (t *WASMChaincode) installedChaincodes(stub shim.ChaincodeStubInterface, args []string) pb.Response {
@@ -258,7 +258,7 @@ func (t *WASMChaincode) installedChaincodes(stub shim.ChaincodeStubInterface, ar
 	return shim.Success([]byte(installedChaincodeNamesList))
 }
 
-func (t *WASMChaincode) invoke(stub shim.ChaincodeStubInterface, args []string) pb.Response {
+func (t *WASMChaincode) execute(stub shim.ChaincodeStubInterface, args []string) pb.Response {
 
 	if len(args) < 2 {
 		return shim.Error("Incorrect number of arguments. Expecting chaincode name to invoke")

--- a/wasmcc/wasmcc_test.go
+++ b/wasmcc/wasmcc_test.go
@@ -71,7 +71,7 @@ var _ = Describe("Tests for wasmcc simple asset transfer", func() {
 		Context("account1 is created with some balance", func() {
 			It("account1 should exist", func() {
 				result := stub.MockInvoke("000",
-					[][]byte{[]byte("invoke"),
+					[][]byte{[]byte("execute"),
 						[]byte("balancewasm"),
 						[]byte("query"),
 						[]byte("account1")})
@@ -90,7 +90,7 @@ var _ = Describe("Tests for wasmcc simple asset transfer", func() {
 		Context("account2 is created with some balance", func() {
 			It("account2 should exist", func() {
 				result := stub.MockInvoke("000",
-					[][]byte{[]byte("invoke"),
+					[][]byte{[]byte("execute"),
 						[]byte("balancewasm"),
 						[]byte("query"),
 						[]byte("account2")})
@@ -109,7 +109,7 @@ var _ = Describe("Tests for wasmcc simple asset transfer", func() {
 		Context("transfer 10 units from account2 to account2", func() {
 			It("transfer should be successful", func() {
 				result := stub.MockInvoke("000",
-					[][]byte{[]byte("invoke"),
+					[][]byte{[]byte("execute"),
 						[]byte("balancewasm"),
 						[]byte("invoke"),
 						[]byte("account2"),
@@ -119,7 +119,7 @@ var _ = Describe("Tests for wasmcc simple asset transfer", func() {
 			})
 			Specify("Account 1 and account 2 balance should be updated to new balance", func() {
 				result := stub.MockInvoke("000",
-					[][]byte{[]byte("invoke"),
+					[][]byte{[]byte("execute"),
 						[]byte("balancewasm"),
 						[]byte("query"),
 						[]byte("account1")})
@@ -132,7 +132,7 @@ var _ = Describe("Tests for wasmcc simple asset transfer", func() {
 				Expect(newExpectedBalAcc1).Should(Equal(newBalAcc1))
 
 				result = stub.MockInvoke("000",
-					[][]byte{[]byte("invoke"),
+					[][]byte{[]byte("execute"),
 						[]byte("balancewasm"),
 						[]byte("query"),
 						[]byte("account2")})


### PR DESCRIPTION
- Renamed function name in wasmcc.go
- Updated corresponding instructions in README
- Updated unit test cases

Fixes #10 